### PR TITLE
Set the number of default threads to 4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     },
     "numberOfWorkingThreads": {
       "type": "integer",
-      "default": "1",
+      "default": "4",
       "description": "number of working threads when lizard python tool is executed. Using a bigger number can fully utilize the CPU and is often faster."
     }
   }


### PR DESCRIPTION
A bigger number is faster and especially this is needed to incerase the 
start up time.